### PR TITLE
Use interpreter backend to avoid runtime issues

### DIFF
--- a/wasmplugin/RATIONALE.md
+++ b/wasmplugin/RATIONALE.md
@@ -1,0 +1,5 @@
+# Why we use Interpreter runtime instead of the Compiler runtime?
+
+We encountered the problem where the compiler runtime caused panic in some cases. This could be a bug in the compiler runtime or a bug in the code we wrote, but we haven't concluded yet. The fact that the interpreter runtime works fine in all cases suggests that the compiler runtime may not be as stable as we would like it to be.
+
+For more details, see https://github.com/musaprg/otelwasm/pull/27.

--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -205,7 +205,8 @@ func NewWasmPlugin(ctx context.Context, cfg *Config, requiredFunctions []string)
 
 // prepareRuntime initializes a new WebAssembly runtime
 func prepareRuntime(ctx context.Context, guestBin []byte) (runtime wazero.Runtime, guest wazero.CompiledModule, err error) {
-	runtime = wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig())
+	// TODO: Switch to compiler backend after fixing the memory allocator issue in wazero
+	runtime = wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigInterpreter())
 
 	guest, err = compileGuest(ctx, runtime, guestBin)
 	if err != nil {


### PR DESCRIPTION
This PR switches to interpreter backend temporarily to avoid various issues coming from compiler backend of wazero. It reduces the performance, but we could come back later once we complete basic implementations.

For more details, see #27 