### PR TITLE
Revert change to the LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,8 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 Kotaro Inoue
-   Copyright 2025 OtelWasm Authors
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -200,4 +199,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-


### PR DESCRIPTION
We shouldn't modify LICENSE text of Apache License 2.0 according to the discussion on https://github.com/kubernetes/kubernetes-template-project/issues/3#issuecomment-262098623

The copyright owner sentence is part of instructions how to apply Apache License 2.0 to files, so its format should be left AS-IS. 