### PR TITLE
Add otlpreceiver

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -14,6 +14,26 @@ require (
 )
 
 require (
+	github.com/knadh/koanf/maps v0.1.2 // indirect
+	github.com/knadh/koanf/providers/confmap v1.0.0 // indirect
+	github.com/knadh/koanf/v2 v2.2.0 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
+	go.opentelemetry.io/collector v0.125.0 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.125.0 // indirect
+	go.opentelemetry.io/collector/config/confignet v1.31.0 // indirect
+	go.opentelemetry.io/collector/confmap v1.31.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.125.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.125.0 // indirect
+	go.opentelemetry.io/collector/internal/sharedcomponent v0.125.0 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.125.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.125.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect
+	sigs.k8s.io/yaml v1.4.0 // indirect
+)
+
+require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.29.14 // indirect
@@ -66,6 +86,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.31.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.125.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.125.0 // indirect
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.125.0
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.125.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -57,6 +57,7 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
 github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -87,6 +88,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mostynb/go-grpc-compression v1.2.3 h1:42/BKWMy0KEJGSdWvzqIyOZ95YcR9mLPqKctH7Uo//I=
+github.com/mostynb/go-grpc-compression v1.2.3/go.mod h1:AghIxF3P57umzqM9yz795+y1Vjs47Km/Y2FE6ouQ7Lg=
 github.com/open-telemetry/opamp-go v0.19.0 h1:8LvQKDwqi+BU3Yy159SU31e2XB0vgnk+PN45pnKilPs=
 github.com/open-telemetry/opamp-go v0.19.0/go.mod h1:9/1G6T5dnJz4cJtoYSr6AX18kHdOxnxxETJPZSHyEUg=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.125.0 h1:+J3dcNdHBzmKcBtYUQYMBpV/h/KBi9dhkpS0euTPvt0=
@@ -110,6 +113,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
+go.opentelemetry.io/collector v0.125.0 h1:pjKuUnxYi0sMZLEV2EEwtCdpwfiltFQLptNhHZb6Hsg=
+go.opentelemetry.io/collector v0.125.0/go.mod h1:s76y9wzw182MlVu8h9fBCw5W4R/nxl2kE6v61+W07rE=
 go.opentelemetry.io/collector/client v1.31.0 h1:PdmUJSx8FgFcrqm12pMwvdVp98aYSdaKjMqJandFIgE=
 go.opentelemetry.io/collector/client v1.31.0/go.mod h1:pSyJ1+XhsLP6nqJDP7uj3AFTw26z9mqCnRGyMw0Im8o=
 go.opentelemetry.io/collector/component v1.31.0 h1:9LzU8X1RhV3h8/QsAoTX23aFUfoJ3EUc9O/vK+hFpSI=
@@ -122,10 +127,14 @@ go.opentelemetry.io/collector/config/configauth v0.125.0 h1:por1HhptIvIbD9wY6TQo
 go.opentelemetry.io/collector/config/configauth v0.125.0/go.mod h1:nL11FOydL0cPxUoAh2HmN95gClcBpaDd34PYbiQbS1U=
 go.opentelemetry.io/collector/config/configcompression v1.31.0 h1:wE3gLe883pfVWBD6BVBUq2XIBPRrM9YTkpn1O8LT3oM=
 go.opentelemetry.io/collector/config/configcompression v1.31.0/go.mod h1:QwbNpaOl6Me+wd0EdFuEJg0Cc+WR42HNjJtdq4TwE6w=
+go.opentelemetry.io/collector/config/configgrpc v0.125.0 h1:X0xBCZM06IBrCpVZAqQ//Vf5V0IiMh07CJw0rDRnfKA=
+go.opentelemetry.io/collector/config/configgrpc v0.125.0/go.mod h1:Kn6jnBJbo/2ZoYN1keZ6kJvkE/Gg6szt49/0cZv8buA=
 go.opentelemetry.io/collector/config/confighttp v0.125.0 h1:t8UscROYhYqJ8xWqfEdkgpx3XlwsZYE4HYB/4hzisqU=
 go.opentelemetry.io/collector/config/confighttp v0.125.0/go.mod h1:vGvspT2O5KMXT4qvQk/iaaMjKEmDvIvLEZw8HAz+QHI=
 go.opentelemetry.io/collector/config/configmiddleware v0.125.0 h1:xvYfPqRK8y91qlMLXsR2dXxknS/hBBTusThml5WhGDk=
 go.opentelemetry.io/collector/config/configmiddleware v0.125.0/go.mod h1:PJPTUHix8WSVcFilqmL5NkN/JtmeXDsqmT92UKqt/8k=
+go.opentelemetry.io/collector/config/confignet v1.31.0 h1:5+33PfypsQfCpdBh5N/HUaTHQrrP1fRQHPW6RFaXxUY=
+go.opentelemetry.io/collector/config/confignet v1.31.0/go.mod h1:HgpLwdRLzPTwbjpUXR0Wdt6pAHuYzaIr8t4yECKrEvo=
 go.opentelemetry.io/collector/config/configopaque v1.31.0 h1:kMCMWnDpAzNwROenG4HZmzDllOy2vRCIcK6wF26GpcE=
 go.opentelemetry.io/collector/config/configopaque v1.31.0/go.mod h1:rw0/X78O8cOk0dhACqNbdiKk1PF7z7mwq9wgSpWoqgs=
 go.opentelemetry.io/collector/config/configtls v1.31.0 h1:s2pvfLeDTLXD3wyJQ3+l2EPTelQinuAYddGP12HyFLQ=
@@ -154,6 +163,8 @@ go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaret
 go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.125.0/go.mod h1:D68nA5XzO/OPeXrxzlLSx2z+tT8e6YyFxdfPQbMXGms=
 go.opentelemetry.io/collector/featuregate v1.31.0 h1:20q7plPQZwmAiaYAa6l1m/i2qDITZuWlhjr4EkmeQls=
 go.opentelemetry.io/collector/featuregate v1.31.0/go.mod h1:Y/KsHbvREENKvvN9RlpiWk/IGBK+CATBYzIIpU7nccc=
+go.opentelemetry.io/collector/internal/sharedcomponent v0.125.0 h1:Fq+3eEyxP6bZzU0P28ZKf5IeHq+vGjRSHWO3ZtJBmJs=
+go.opentelemetry.io/collector/internal/sharedcomponent v0.125.0/go.mod h1:fiFQva6CmZ7Fi50Di/3QDxBmTK3K4lpNUJxiuxg10bk=
 go.opentelemetry.io/collector/internal/telemetry v0.125.0 h1:6lcGOxw3dAg7LfXTKdN8ZjR+l7KvzLdEiPMhhLwG4r4=
 go.opentelemetry.io/collector/internal/telemetry v0.125.0/go.mod h1:5GyFslLqjZgq1DZTtFiluxYhhXrCofHgOOOybodDPGE=
 go.opentelemetry.io/collector/pdata v1.31.0 h1:P5WuLr1l2JcIvr6Dw2hl01ltp2ZafPnC4Isv+BLTBqU=
@@ -164,6 +175,8 @@ go.opentelemetry.io/collector/pipeline v0.125.0 h1:oitBgcAFqntDB4ihQJUHJSQ8IHqKF
 go.opentelemetry.io/collector/pipeline v0.125.0/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.31.0 h1:OSRrCWclb1QmGPnxFMxQsdegua4vlKpZESOtDKSzKeQ=
 go.opentelemetry.io/collector/receiver v1.31.0/go.mod h1:zPUiv3jgJGQSY01nx500cYJiEz6JfaR53BAvCW2tgGs=
+go.opentelemetry.io/collector/receiver/otlpreceiver v0.125.0 h1:pkC4uHg58F1ohvuEgKC/8498hsqUjq71RKPsKXdV3jw=
+go.opentelemetry.io/collector/receiver/otlpreceiver v0.125.0/go.mod h1:k9ud3MU74rhSCtPCJ/IxlRo6cn7jEVhJSq+f5brSkZI=
 go.opentelemetry.io/collector/receiver/receiverhelper v0.125.0 h1:5tHjNtrJ1oNagyWSV346Y4M4UVBGJBkI+HQpGVts5sM=
 go.opentelemetry.io/collector/receiver/receiverhelper v0.125.0/go.mod h1:iD0Jowq3E2+Bvrq4cna4ziM6XmfMCh+E+d+ftq1i0qU=
 go.opentelemetry.io/collector/receiver/receivertest v0.125.0 h1:xV3Jm3OT7SfDpJ5mXhNmK/Nch7f41whA8k0q4XkaWT8=
@@ -174,6 +187,8 @@ go.opentelemetry.io/collector/semconv v0.125.0 h1:SyRP617YGvNSWRSKMy7Lbk9RaJSR+q
 go.opentelemetry.io/collector/semconv v0.125.0/go.mod h1:te6VQ4zZJO5Lp8dM2XIhDxDiL45mwX0YAQQWRQ0Qr9U=
 go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 h1:ojdSRDvjrnm30beHOmwsSvLpoRF40MlwNCA+Oo93kXU=
 go.opentelemetry.io/contrib/bridges/otelzap v0.10.0/go.mod h1:oTTm4g7NEtHSV2i/0FeVdPaPgUIZPfQkFbq0vbzqnv0=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 h1:x7wzEgXfnzJcHDwStJT+mxOz4etr2EcexjqhBvmoakw=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0/go.mod h1:rg+RlpR5dKwaS95IyyZqj5Wd4E13lk/msnTS0Xl9lJM=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 h1:sbiXRNDSWJOTobXh5HyQKjq6wUC5tNybqjIqDpAY4CU=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0/go.mod h1:69uWxva0WgAA/4bu2Yy70SLDBwZXuQ6PbBpbsa5iZrQ=
 go.opentelemetry.io/otel v1.35.0 h1:xKWKPxrxB6OtMCbmMY021CqC45J+3Onta9MqjhnusiQ=
@@ -231,6 +246,7 @@ google.golang.org/grpc v1.72.0 h1:S7UkcVa60b5AAQTaO6ZKamFp1zMZSU0fGDK2WZLbBnM=
 google.golang.org/grpc v1.72.0/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
 google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/examples/receiver/otlpreceiver/main.go
+++ b/examples/receiver/otlpreceiver/main.go
@@ -13,6 +13,7 @@ import (
 
 // TODO: Fix the bug when using the gRPC endpoint.
 // Currently, the gRPC endpoint is not working properly due to the panic while handling the incoming request.
+// For more details, see https://github.com/otelwasm/otelwasm/issues/59
 
 func init() {
 	logger, err := zap.NewProduction()

--- a/examples/receiver/otlpreceiver/main.go
+++ b/examples/receiver/otlpreceiver/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"github.com/otelwasm/otelwasm/guest/api"
+	"github.com/otelwasm/otelwasm/guest/factoryconnector"
+	"github.com/otelwasm/otelwasm/guest/plugin" // register receivers
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+	"go.uber.org/zap"
+)
+
+// TODO: Fix the bug when using the gRPC endpoint.
+// Currently, the gRPC endpoint is not working properly due to the panic while handling the incoming request.
+
+func init() {
+	logger, err := zap.NewProduction()
+	if err != nil {
+		panic(err)
+	}
+
+	factory := otlpreceiver.NewFactory()
+	telemetrySettings := componenttest.NewNopTelemetrySettings()
+	telemetrySettings.Logger = logger
+
+	settings := receiver.Settings{
+		ID:                component.MustNewID("otlp"),
+		TelemetrySettings: telemetrySettings,
+		BuildInfo:         component.NewDefaultBuildInfo(),
+	}
+
+	connector := factoryconnector.NewReceiverConnector(factory, settings)
+
+	plugin.Set(struct {
+		api.MetricsReceiver
+		api.LogsReceiver
+		api.TracesReceiver
+	}{
+		connector.Metrics(),
+		connector.Logs(),
+		connector.Traces(),
+	})
+}
+func main() {}


### PR DESCRIPTION
I've checked that only OTLP/HTTP endpoint is working properly. As for gRPC endpoint, the process panics while handling the first incoming telemetry data. We should investigate and fix it, but we'll only support OTLP/HTTP at the moment in the wasm receiver.

For more details about errors of gRPC, see #59.

## Test result

<details><summary>Collector Config</summary>

```yaml
receivers:
  wasm/otlpreceiver:
    path: "./examples/receiver/otlpreceiver/main.wasm"
processors:
  wasm/nop:
    path: "./examples/processor/nop/main.wasm"
exporters:
  wasm:
    path: "./examples/exporter/stdout/main.wasm"

service:
  pipelines:
    traces:
      receivers: [wasm/otlpreceiver]
      processors: [wasm/nop]
      exporters: [wasm]
```

</details>

<details><summary>Commands used to send sample telemetry data</summary>

```shell-session
❯ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 otel-cli exec --service my-service --name "curl google" curl https://google.com
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="https://www.google.com/">here</A>.
</BODY></HTML>
```

</details>

<details><summary>OpenTelemetry Collector logs</summary>

```shell-session
❯ ./bin/otelwasmcol_darwin_arm64 --config ./config.yaml
2025-05-05T22:58:18.434+0900    info    service@v0.125.0/service.go:199 Setting up own telemetry...
2025-05-05T22:58:20.450+0900    info    service@v0.125.0/service.go:266 Starting otelwasmcol... {"Version": "", "NumCPU": 10}
2025-05-05T22:58:20.450+0900    info    extensions/extensions.go:41     Starting extensions...
2025-05-05T22:58:20.451+0900    info    service@v0.125.0/service.go:289 Everything is ready. Begin running and processing data.
{"level":"info","ts":1746453500.454307,"caller":"otlpreceiver@v0.125.0/otlp.go:116","msg":"Starting GRPC server","endpoint":"localhost:4317"}
{"level":"info","ts":1746453500.459969,"caller":"otlpreceiver@v0.125.0/otlp.go:173","msg":"Starting HTTP server","endpoint":"localhost:4318"}
{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"my-service"}}]},"scopeSpans":[{"scope":{"name":"github.com/equinix-labs/otel-cli","version":"0.4.5 Homebrew 2024-04-01T20:54:17Z"},"spans":[{"traceId":"ec10bb0bc73372c3295b5dee33ba4b98","spanId":"1f555627579dc9f7","parentSpanId":"","name":"curl google","kind":3,"startTimeUnixNano":"1746453509149274000","endTimeUnixNano":"1746453509363887000","attributes":[{"key":"process.command","value":{"stringValue":"curl"}},{"key":"process.command_args","value":{"arrayValue":{"values":[{"stringValue":"curl"},{"stringValue":"https://google.com"}]}}},{"key":"process.owner","value":{"stringValue":"musaprg"}},{"key":"process.pid","value":{"intValue":"77384"}},{"key":"process.parent_pid","value":{"intValue":"77389"}}],"status":{}}],"schemaUrl":"https://opentelemetry.io/schemas/1.17.0"}],"schemaUrl":"https://opentelemetry.io/schemas/1.17.0"}]}
```

</details>