### PR TITLE
Add nop processor benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,15 @@ copy-wasm-examples: build-wasm-examples
 		cp "$$example" "$${target_dir}/"; \
 	done
 
+.PHONY: benchmark
+benchmark: copy-wasm-examples
+	@echo "Running benchmarks for all modules..."
+	@(cd wasmprocessor; $(GOCMD) test -run='^$$' -bench=. -benchmem -tags docker)
+	@(cd wasmexporter; $(GOCMD) test -run='^$$' -bench=. -benchmem -tags docker)
+	@(cd wasmreceiver; $(GOCMD) test -run='^$$' -bench=. -benchmem -tags docker)
+	@(cd guest; $(GOCMD) test -run='^$$' -bench=. -benchmem -tags docker ./...)
+	@echo "Benchmarks completed."
+
 .PHONY: docker-otelwasmcol
 docker-otelwasmcol:
 	GOOS=linux GOARCH=$(GOARCH) $(MAKE) otelwasmcol
@@ -73,4 +82,3 @@ genotelwasmcol:
 otelwasmcol: genotelwasmcol
 	cd ./cmd/otelwasmcol && GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -trimpath -o ../../bin/otelwasmcol_$(GOOS)_$(GOARCH)$(EXTENSION) \
 		-tags $(GO_BUILD_TAGS) .
-

--- a/wasmprocessor/benchmark_test.go
+++ b/wasmprocessor/benchmark_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/otelwasm/otelwasm/wasmplugin"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -24,10 +25,47 @@ func generateExampleTraces() ptrace.Traces {
 	return td
 }
 
-func BenchmarkNopProcessorWasm(b *testing.B) {
+func BenchmarkNopProcessorWasmInterpreter(b *testing.B) {
 	// Test that the processor can be created with the default config
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Path = "testdata/nop/main.wasm"
+	ctx := b.Context()
+
+	// Test for traces
+	settings := processortest.NewNopSettings(typeStr)
+	tp, err := factory.CreateTraces(ctx, settings, cfg, consumertest.NewNop())
+	if err != nil {
+		b.Fatalf("failed to create traces processor: %v", err)
+	}
+	if tp == nil {
+		b.Fatal("traces processor is nil")
+	}
+
+	if err := tp.Start(ctx, componenttest.NewNopHost()); err != nil {
+		b.Errorf("failed to start processor: %v", err)
+	}
+
+	td := generateExampleTraces()
+
+	b.Run("process traces", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if err := tp.ConsumeTraces(ctx, td); err != nil {
+				b.Errorf("failed to consume traces: %v", err)
+			}
+		}
+	})
+
+	if err := tp.Shutdown(ctx); err != nil {
+		b.Errorf("failed to shutdown processor: %v", err)
+	}
+}
+
+func BenchmarkNopProcessorWasmCompiled(b *testing.B) {
+	// Test that the processor can be created with the default config
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.RuntimeConfig.Mode = wasmplugin.RuntimeModeCompiled
 	cfg.Path = "testdata/nop/main.wasm"
 	ctx := b.Context()
 

--- a/wasmprocessor/benchmark_test.go
+++ b/wasmprocessor/benchmark_test.go
@@ -1,0 +1,95 @@
+package wasmprocessor
+
+import (
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/processor/processortest"
+)
+
+func generateExampleTraces() ptrace.Traces {
+	td := ptrace.NewTraces()
+	resourceSpans := td.ResourceSpans().AppendEmpty()
+	resourceSpans.Resource().Attributes().PutStr("example_key", "example_value")
+	span := resourceSpans.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetName("example_span")
+	span.SetKind(ptrace.SpanKindServer)
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(1 * time.Second)))
+	span.Attributes().PutStr("example_span_key", "example_span_value")
+	return td
+}
+
+func BenchmarkNopProcessorWasm(b *testing.B) {
+	// Test that the processor can be created with the default config
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Path = "testdata/nop/main.wasm"
+	ctx := b.Context()
+
+	// Test for traces
+	settings := processortest.NewNopSettings(typeStr)
+	tp, err := factory.CreateTraces(ctx, settings, cfg, consumertest.NewNop())
+	if err != nil {
+		b.Fatalf("failed to create traces processor: %v", err)
+	}
+	if tp == nil {
+		b.Fatal("traces processor is nil")
+	}
+
+	if err := tp.Start(ctx, componenttest.NewNopHost()); err != nil {
+		b.Errorf("failed to start processor: %v", err)
+	}
+
+	td := generateExampleTraces()
+
+	b.Run("process traces", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if err := tp.ConsumeTraces(ctx, td); err != nil {
+				b.Errorf("failed to consume traces: %v", err)
+			}
+		}
+	})
+
+	if err := tp.Shutdown(ctx); err != nil {
+		b.Errorf("failed to shutdown processor: %v", err)
+	}
+}
+
+func BenchmarkNopProcessorGo(b *testing.B) {
+	factory := processortest.NewNopFactory()
+	cfg := factory.CreateDefaultConfig()
+	ctx := b.Context()
+
+	// Test for traces
+	settings := processortest.NewNopSettings(processortest.NopType)
+	tp, err := factory.CreateTraces(ctx, settings, cfg, consumertest.NewNop())
+	if err != nil {
+		b.Fatalf("failed to create traces processor: %v", err)
+	}
+	if tp == nil {
+		b.Fatal("traces processor is nil")
+	}
+
+	if err := tp.Start(ctx, componenttest.NewNopHost()); err != nil {
+		b.Errorf("failed to start processor: %v", err)
+	}
+
+	td := generateExampleTraces()
+
+	b.Run("process traces", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if err := tp.ConsumeTraces(ctx, td); err != nil {
+				b.Errorf("failed to consume traces: %v", err)
+			}
+		}
+	})
+
+	if err := tp.Shutdown(ctx); err != nil {
+		b.Errorf("failed to shutdown processor: %v", err)
+	}
+}


### PR DESCRIPTION
Part of https://github.com/otelwasm/otelwasm/issues/7

This PR adds basic benchmark of wasmprocessor with nop processor implementation.

```
❯ make benchmark                         
Running benchmarks for all modules...
goos: darwin
goarch: arm64
pkg: github.com/otelwasm/otelwasm/wasmprocessor
cpu: Apple M1 Max
BenchmarkNopProcessorWasmInterpreter/process_traces-10              4185            296062 ns/op           13191 B/op        257 allocs/op
BenchmarkNopProcessorWasmCompiled/process_traces-10                89493             13422 ns/op            1144 B/op         26 allocs/op
BenchmarkNopProcessorGo/process_traces-10                       404211830                2.988 ns/op           0 B/op          0 allocs/op
PASS
ok      github.com/otelwasm/otelwasm/wasmprocessor      10.267s
PASS
ok      github.com/otelwasm/otelwasm/wasmexporter       0.274s
PASS
ok      github.com/otelwasm/otelwasm/wasmreceiver       0.336s
?       github.com/otelwasm/otelwasm/guest/api  [no test files]
?       github.com/otelwasm/otelwasm/guest/factoryconnector     [no test files]
?       github.com/otelwasm/otelwasm/guest/imports      [no test files]
?       github.com/otelwasm/otelwasm/guest/internal/imports     [no test files]
?       github.com/otelwasm/otelwasm/guest/internal/mem [no test files]
PASS
ok      github.com/otelwasm/otelwasm/guest/internal/plugin      0.234s
?       github.com/otelwasm/otelwasm/guest/logsexporter [no test files]
?       github.com/otelwasm/otelwasm/guest/logsprocessor        [no test files]
?       github.com/otelwasm/otelwasm/guest/logsreceiver [no test files]
?       github.com/otelwasm/otelwasm/guest/metricsexporter      [no test files]
?       github.com/otelwasm/otelwasm/guest/metricsprocessor     [no test files]
?       github.com/otelwasm/otelwasm/guest/metricsreceiver      [no test files]
?       github.com/otelwasm/otelwasm/guest/plugin       [no test files]
?       github.com/otelwasm/otelwasm/guest/tracesexporter       [no test files]
?       github.com/otelwasm/otelwasm/guest/tracesprocessor      [no test files]
?       github.com/otelwasm/otelwasm/guest/tracesreceiver       [no test files]
```