### PR TITLE
Add factorybuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,6 @@ go.work.sum
 # env file
 .env
 
+bin/
 otelcol-dev/
 ocb

--- a/Makefile
+++ b/Makefile
@@ -82,3 +82,7 @@ genotelwasmcol:
 otelwasmcol: genotelwasmcol
 	cd ./cmd/otelwasmcol && GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -trimpath -o ../../bin/otelwasmcol_$(GOOS)_$(GOARCH)$(EXTENSION) \
 		-tags $(GO_BUILD_TAGS) .
+
+.PHONY: factorybuilder
+factorybuilder:
+	$(GOCMD) build -o bin/factorybuilder ./cmd/factorybuilder

--- a/cmd/factorybuilder/README.md
+++ b/cmd/factorybuilder/README.md
@@ -1,0 +1,14 @@
+# factorybuilder
+* Build existing OpenTelemetry Collector components into wasm files for otelwasm
+
+## Installation
+```console
+$ go install github.com/otelwasm/otelwasm/cmd/factorybuilder@latest
+```
+
+## Usage
+* Build attributesprocessor
+
+```
+$ factorybuilder -o main.wasm github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
+```

--- a/cmd/factorybuilder/builder.go
+++ b/cmd/factorybuilder/builder.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+//go:embed templates/*.gotmpl
+var templates embed.FS
+
+type ComponentType string
+
+const (
+	Receiver  ComponentType = "receiver"
+	Processor ComponentType = "processor"
+	Exporter  ComponentType = "exporter"
+)
+
+type Builder struct {
+	WorkDir       string
+	ComponentType ComponentType
+	Package       string
+	PackageName   string
+	Output        string
+}
+
+func (b *Builder) Prepare() error {
+	err := os.MkdirAll(b.WorkDir, 0o755)
+	if err != nil {
+		return fmt.Errorf("failed to create workdir %s: %w", workDir, err)
+	}
+
+	err = b.exec("go", "mod", "init", b.PackageName)
+	if err != nil {
+		return fmt.Errorf("failed to init go module: %w", err)
+	}
+
+	err = b.exec("go", "get", b.Package)
+	if err != nil {
+		return fmt.Errorf("failed to get package %s: %w", b.Package, err)
+	}
+
+	err = b.exec("go", "mod", "edit", "-tool=github.com/otelwasm/wasibuilder")
+	if err != nil {
+		return fmt.Errorf("failed to add wasibuilder as tool: %w", err)
+	}
+
+	dst := filepath.Join(b.WorkDir, "main.go")
+	tmplName := strings.ToLower(string(b.ComponentType)) + ".gotmpl"
+
+	err = b.writeTemplate(dst, tmplName, map[string]any{
+		"UpstreamPackage": b.Package,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to write template %s: %w", tmplName, err)
+	}
+
+	err = b.exec("go", "mod", "tidy")
+	if err != nil {
+		return fmt.Errorf("failed to tidy go module: %w", err)
+	}
+
+	return nil
+}
+
+func (b *Builder) Build() error {
+	output, err := filepath.Abs(b.Output)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path of output file %s: %w", b.Output, err)
+	}
+
+	err = b.exec("go", "tool", "wasibuilder", "go", "build", "-o", output, ".")
+	if err != nil {
+		return fmt.Errorf("failed to build package %s: %w", b.Package, err)
+	}
+
+	return nil
+}
+
+func (b *Builder) Clean() error {
+	err := os.RemoveAll(b.WorkDir)
+	if err != nil {
+		return fmt.Errorf("failed to remove workdir %s: %w", b.WorkDir, err)
+	}
+
+	return nil
+}
+
+func (b *Builder) exec(command string, args ...string) error {
+	cmd := exec.Command(command, args...)
+	cmd.Dir = b.WorkDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+func (b *Builder) writeTemplate(dst, templateName string, data interface{}) error {
+	templatePath := filepath.Join("templates", templateName)
+
+	tmpl := template.Must(template.ParseFS(templates, templatePath))
+
+	var buf bytes.Buffer
+	err := tmpl.ExecuteTemplate(&buf, templateName, data)
+	if err != nil {
+		return fmt.Errorf("failed to execute template %s: %w", templateName, err)
+	}
+
+	err = os.WriteFile(dst, buf.Bytes(), 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to write template %s: %w", dst, err)
+	}
+
+	return nil
+}

--- a/cmd/factorybuilder/main.go
+++ b/cmd/factorybuilder/main.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+var (
+	output        string
+	componentType ComponentType
+	workDir       string
+	remain        bool
+)
+
+func init() {
+	flag.StringVar(&output, "o", "", "output file (default: {package}.wasm)")
+	flag.StringVar((*string)(&componentType), "type", "", "component type: receiver, processor, exporter (default: detect from package)")
+	flag.StringVar(&workDir, "workdir", "", "working directory (default: ./{package})")
+	flag.BoolVar(&remain, "remain", false, "keep the working directory after build")
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s {package}\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+
+	flag.Parse()
+}
+
+func detectComponentType(packagePath string) ComponentType {
+	switch {
+	case strings.Contains(packagePath, "receiver"):
+		return Receiver
+	case strings.Contains(packagePath, "processor"):
+		return Processor
+	case strings.Contains(packagePath, "exporter"):
+		return Exporter
+	default:
+		return ""
+	}
+}
+
+func main() {
+	if flag.NArg() == 0 {
+		flag.Usage()
+		return
+	}
+	packagePath := flag.Arg(0)
+	split := strings.Split(packagePath, "/")
+	packageName := split[len(split)-1]
+
+	if output == "" {
+		output = packageName + ".wasm"
+	}
+
+	if componentType == "" {
+		componentType = detectComponentType(packagePath)
+	}
+	if componentType == "" {
+	}
+	switch componentType {
+	case Receiver, Processor, Exporter:
+		// OK
+	case "":
+		slog.Error("Could not detect component type from package path", "packagePath", packagePath)
+		slog.Info("Please specify the component type using -type flag")
+		os.Exit(1)
+	default:
+		slog.Error("Invalid component type", "componentType", componentType)
+		slog.Info("Valid component types are: receiver, processor, exporter")
+		os.Exit(1)
+	}
+
+	if workDir == "" {
+		workDir = packageName
+	}
+
+	builder := &Builder{
+		WorkDir:       workDir,
+		ComponentType: componentType,
+		Package:       packagePath,
+		PackageName:   packageName,
+		Output:        output,
+	}
+
+	exitCode := 0
+	defer func() {
+		recovered := recover()
+
+		if remain {
+			slog.Info("Working directory will be kept", "workDir", workDir)
+
+			os.Exit(exitCode)
+		}
+
+		err := builder.Clean()
+		if err != nil {
+			slog.Warn("Failed to clean up", "error", err)
+		}
+
+		if recovered != nil {
+			os.Exit(exitCode)
+		}
+	}()
+
+	err := builder.Prepare()
+	if err != nil {
+		slog.Error("Failed to prepare build", "error", err)
+		panic(err)
+	}
+	err = builder.Build()
+	if err != nil {
+		slog.Error("Failed to build package", "error", err)
+		panic(err)
+	}
+
+	slog.Info("Build completed successfully", "output", output)
+}

--- a/cmd/factorybuilder/templates/exporter.gotmpl
+++ b/cmd/factorybuilder/templates/exporter.gotmpl
@@ -1,0 +1,42 @@
+package main
+
+import (
+	upstream "{{ .UpstreamPackage }}"
+	"github.com/otelwasm/otelwasm/guest/api"
+	"github.com/otelwasm/otelwasm/guest/factoryconnector"
+	"github.com/otelwasm/otelwasm/guest/plugin"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/exporter"
+	"go.uber.org/zap"
+)
+
+func init() {
+	logger, err := zap.NewProduction()
+	if err != nil {
+		panic(err)
+	}
+
+	factory := upstream.NewFactory()
+	telemetrySettings := componenttest.NewNopTelemetrySettings()
+	telemetrySettings.Logger = logger
+
+	settings := exporter.Settings{
+		ID:                component.MustNewID(factory.Type().String()),
+		TelemetrySettings: telemetrySettings,
+		BuildInfo:         component.NewDefaultBuildInfo(),
+	}
+
+	connector := factoryconnector.NewExporterConnector(factory, settings)
+
+	plugin.Set(struct {
+		api.LogsExporter
+		api.MetricsExporter
+		api.TracesExporter
+	}{
+		connector.Logs(),
+		connector.Metrics(),
+		connector.Traces(),
+	})
+}
+func main() {}

--- a/cmd/factorybuilder/templates/processor.gotmpl
+++ b/cmd/factorybuilder/templates/processor.gotmpl
@@ -1,0 +1,42 @@
+package main
+
+import (
+	upstream "{{ .UpstreamPackage }}"
+	"github.com/otelwasm/otelwasm/guest/api"
+	"github.com/otelwasm/otelwasm/guest/factoryconnector"
+	"github.com/otelwasm/otelwasm/guest/plugin"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/processor"
+	"go.uber.org/zap"
+)
+
+func init() {
+	logger, err := zap.NewProduction()
+	if err != nil {
+		panic(err)
+	}
+
+	factory := upstream.NewFactory()
+	telemetrySettings := componenttest.NewNopTelemetrySettings()
+	telemetrySettings.Logger = logger
+
+	settings := processor.Settings{
+		ID:                component.MustNewID(factory.Type().String()),
+		TelemetrySettings: telemetrySettings,
+		BuildInfo:         component.NewDefaultBuildInfo(),
+	}
+
+	connector := factoryconnector.NewProcessorConnector(factory, settings)
+
+	plugin.Set(struct {
+		api.LogsProcessor
+		api.MetricsProcessor
+		api.TracesProcessor
+	}{
+		connector.Logs(),
+		connector.Metrics(),
+		connector.Traces(),
+	})
+}
+func main() {}

--- a/cmd/factorybuilder/templates/receiver.gotmpl
+++ b/cmd/factorybuilder/templates/receiver.gotmpl
@@ -1,0 +1,42 @@
+package main
+
+import (
+	upstream "{{ .UpstreamPackage }}"
+	"github.com/otelwasm/otelwasm/guest/api"
+	"github.com/otelwasm/otelwasm/guest/factoryconnector"
+	"github.com/otelwasm/otelwasm/guest/plugin"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/zap"
+)
+
+func init() {
+	logger, err := zap.NewProduction()
+	if err != nil {
+		panic(err)
+	}
+
+	factory := upstream.NewFactory()
+	telemetrySettings := componenttest.NewNopTelemetrySettings()
+	telemetrySettings.Logger = logger
+
+	settings := receiver.Settings{
+		ID:                component.MustNewID(factory.Type().String()),
+		TelemetrySettings: telemetrySettings,
+		BuildInfo:         component.NewDefaultBuildInfo(),
+	}
+
+	connector := factoryconnector.NewReceiverConnector(factory, settings)
+
+	plugin.Set(struct {
+		api.LogsReceiver
+		api.MetricsReceiver
+		api.TracesReceiver
+	}{
+		connector.Logs(),
+		connector.Metrics(),
+		connector.Traces(),
+	})
+}
+func main() {}


### PR DESCRIPTION
```
❯ factorybuilder github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
go: creating new go.mod: module attributesprocessor
go: added github.com/alecthomas/participle/v2 v2.1.4
go: added github.com/antchfx/xmlquery v1.4.4
go: added github.com/antchfx/xpath v1.3.4
go: added github.com/cespare/xxhash/v2 v2.3.0
go: added github.com/elastic/go-grok v0.3.1
go: added github.com/elastic/lunes v0.1.0
go: added github.com/expr-lang/expr v1.17.2
go: added github.com/go-logr/logr v1.4.2
go: added github.com/go-logr/stdr v1.2.2
go: added github.com/gobwas/glob v0.2.3
go: added github.com/goccy/go-json v0.10.5
go: added github.com/gogo/protobuf v1.3.2
go: added github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
go: added github.com/google/uuid v1.6.0
go: added github.com/hashicorp/go-version v1.7.0
go: added github.com/hashicorp/golang-lru v0.5.4
go: added github.com/hashicorp/golang-lru/v2 v2.0.7
go: added github.com/iancoleman/strcase v0.3.0
go: added github.com/json-iterator/go v1.1.12
go: added github.com/magefile/mage v1.15.0
go: added github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: added github.com/modern-go/reflect2 v1.0.2
go: added github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.126.0
go: added github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.126.0
go: added github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.126.0
go: added github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.126.0
go: added github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.126.0
go: added github.com/twmb/murmur3 v1.1.8
go: added github.com/ua-parser/uap-go v0.0.0-20240611065828-3a4781585db6
go: added go.opentelemetry.io/auto/sdk v1.1.0
go: added go.opentelemetry.io/collector/client v1.32.0
go: added go.opentelemetry.io/collector/component v1.32.0
go: added go.opentelemetry.io/collector/consumer v1.32.0
go: added go.opentelemetry.io/collector/featuregate v1.32.0
go: added go.opentelemetry.io/collector/internal/telemetry v0.126.0
go: added go.opentelemetry.io/collector/pdata v1.32.0
go: added go.opentelemetry.io/collector/pdata/pprofile v0.126.0
go: added go.opentelemetry.io/collector/pipeline v0.126.0
go: added go.opentelemetry.io/collector/processor v1.32.0
go: added go.opentelemetry.io/collector/processor/processorhelper v0.126.0
go: added go.opentelemetry.io/contrib/bridges/otelzap v0.10.0
go: added go.opentelemetry.io/otel v1.35.0
go: added go.opentelemetry.io/otel/log v0.11.0
go: added go.opentelemetry.io/otel/metric v1.35.0
go: added go.opentelemetry.io/otel/sdk v1.35.0
go: added go.opentelemetry.io/otel/trace v1.35.0
go: added go.uber.org/multierr v1.11.0
go: added go.uber.org/zap v1.27.0
go: added golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
go: added golang.org/x/net v0.40.0
go: added golang.org/x/sys v0.33.0
go: added golang.org/x/text v0.25.0
go: added google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a
go: added google.golang.org/grpc v1.72.0
go: added google.golang.org/protobuf v1.36.6
go: added gopkg.in/yaml.v2 v2.4.0
go: finding module for package github.com/otelwasm/wasibuilder
go: finding module for package github.com/otelwasm/otelwasm/guest/plugin
go: finding module for package github.com/otelwasm/otelwasm/guest/api
go: finding module for package github.com/otelwasm/otelwasm/guest/factoryconnector
go: found github.com/otelwasm/otelwasm/guest/api in github.com/otelwasm/otelwasm/guest v0.0.0-20250515132814-d74c7946f768
go: found github.com/otelwasm/otelwasm/guest/factoryconnector in github.com/otelwasm/otelwasm/guest v0.0.0-20250515132814-d74c7946f768
go: found github.com/otelwasm/otelwasm/guest/plugin in github.com/otelwasm/otelwasm/guest v0.0.0-20250515132814-d74c7946f768
2025/05/16 17:26:04 INFO Build completed successfully output=attributesprocessor.wasm

```