### PR TITLE
fix: build command for factorybuilder

### DIFF
--- a/cmd/factorybuilder/builder.go
+++ b/cmd/factorybuilder/builder.go
@@ -75,7 +75,7 @@ func (b *Builder) Build() error {
 		return fmt.Errorf("failed to get absolute path of output file %s: %w", b.Output, err)
 	}
 
-	err = b.exec("go", "tool", "wasibuilder", "go", "build", "-o", output, ".")
+	err = b.exec("go", "tool", "wasibuilder", "go", "build", "-buildmode=c-shared", "-o", output, ".")
 	if err != nil {
 		return fmt.Errorf("failed to build package %s: %w", b.Package, err)
 	}


### PR DESCRIPTION
`-buildmode=c-shared` was missing.

```
❯ ../bin/otelwasmcol_darwin_arm64 --config otel-config.yaml
2025-05-16T22:20:19.002+0900    info    service@v0.125.0/service.go:199 Setting up own telemetry...
runtime: wasmexport function called before runtime initialization
        call _start first
Error: failed to build pipelines: failed to create "wasm/otlphttpexporter" exporter for data type "logs": failed to check logs support status: wasm: failed to get supported telemetry types: wasm error: unreachable
wasm stack trace:
        .runtime.abort(i32) i32
        .runtime.notInitialized()
        .getSupportedTelemetry() i32
2025/05/16 22:20:19 collector server run finished with error: failed to build pipelines: failed to create "wasm/otlphttpexporter" exporter for data type "logs": failed to check logs support status: wasm: failed to get supported telemetry types: wasm error: unreachable
wasm stack trace:
        .runtime.abort(i32) i32
        .runtime.notInitialized()
        .getSupportedTelemetry() i32s
```