### PR TITLE
Add clean make target to remove generated files by ocb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
 wasibuilder   := github.com/otelwasm/wasibuilder@v0.0.6
 
-SRC_ROOT := $(git rev-parse --show-toplevel)
+SRC_ROOT := $(shell git rev-parse --show-toplevel)
 
 GOCMD?= go
 GO_BUILD_TAGS=""
@@ -86,3 +86,7 @@ otelwasmcol: genotelwasmcol
 .PHONY: factorybuilder
 factorybuilder:
 	$(GOCMD) build -o bin/factorybuilder ./cmd/factorybuilder
+
+.PHONY: clean
+clean:
+	@find ./cmd/otelwasmcol -type f ! -name 'Dockerfile' ! -name '.gitignore' ! -name 'builder-config.yaml' -delete


### PR DESCRIPTION
This PR adds `clean` make target to remove files generated by ocb.