### PR TITLE
Update wasmplugin rationale wording

### DIFF
--- a/wasmplugin/RATIONALE.md
+++ b/wasmplugin/RATIONALE.md
@@ -1,5 +1,5 @@
 # Why we use Interpreter runtime instead of the Compiler runtime?
 
-We encountered the problem where the compiler runtime caused panic in some cases. This could be a bug in the compiler runtime or a bug in the code we wrote, but we haven't concluded yet. The fact that the interpreter runtime works fine in all cases suggests that the compiler runtime may not be as stable as we would like it to be.
+We originally encountered a compiler-runtime panic in some cases. That issue was later resolved by [#83](https://github.com/otelwasm/otelwasm/pull/83) and its follow-up [#84](https://github.com/otelwasm/otelwasm/pull/84). We still prefer interpreter mode because it is more stable than compilation mode.
 
 For more details, see https://github.com/otelwasm/otelwasm/pull/27.


### PR DESCRIPTION
This is a follow-up PR of #83 and #84. The original issue was resolved, but we still put the default mode as `interpreter` as it's more stable than `compiler`. We may switch to using `compiler` as a default runtime once we confirm it's stable and faster, but it's worth putting it on hold atm.